### PR TITLE
#178 Add distribution curves to stack initialization

### DIFF
--- a/game_logic/gameplay_enums.gd
+++ b/game_logic/gameplay_enums.gd
@@ -15,3 +15,8 @@ enum ItemType {
 	AMMO,
 	CONSUMABLE
 }
+
+enum StackRandomMethod {
+	RANDOM,
+	NORMAL
+}

--- a/game_objects/items/ammo/fic/fic_box_ap_inventory_info.tres
+++ b/game_objects/items/ammo/fic/fic_box_ap_inventory_info.tres
@@ -32,3 +32,6 @@ column_span = 1
 row_span = 1
 description_text = ""
 flavor_text = ""
+min_pickup_stacks = 1
+mean_pickup_stacks = 10
+stack_random_method = 1

--- a/game_objects/items/ammo/fic/fic_box_fmj_inventory_info.tres
+++ b/game_objects/items/ammo/fic/fic_box_fmj_inventory_info.tres
@@ -32,3 +32,6 @@ column_span = 1
 row_span = 1
 description_text = ""
 flavor_text = ""
+min_pickup_stacks = 1
+mean_pickup_stacks = 10
+stack_random_method = 1

--- a/game_objects/items/ammo/fic/fic_box_hp_inventory_info.tres
+++ b/game_objects/items/ammo/fic/fic_box_hp_inventory_info.tres
@@ -32,3 +32,6 @@ column_span = 1
 row_span = 1
 description_text = ""
 flavor_text = ""
+min_pickup_stacks = 1
+mean_pickup_stacks = 10
+stack_random_method = 1

--- a/game_objects/items/ammo/hic/hic_box_ap_inventory_info.tres
+++ b/game_objects/items/ammo/hic/hic_box_ap_inventory_info.tres
@@ -32,3 +32,6 @@ column_span = 1
 row_span = 1
 description_text = ""
 flavor_text = ""
+min_pickup_stacks = 1
+mean_pickup_stacks = 10
+stack_random_method = 1

--- a/game_objects/items/ammo/hic/hic_box_fmj_inventory_info.tres
+++ b/game_objects/items/ammo/hic/hic_box_fmj_inventory_info.tres
@@ -32,3 +32,6 @@ column_span = 1
 row_span = 1
 description_text = ""
 flavor_text = ""
+min_pickup_stacks = 1
+mean_pickup_stacks = 10
+stack_random_method = 1

--- a/game_objects/items/ammo/hic/hic_box_hp_inventory_info.tres
+++ b/game_objects/items/ammo/hic/hic_box_hp_inventory_info.tres
@@ -32,3 +32,6 @@ column_span = 1
 row_span = 1
 description_text = ""
 flavor_text = ""
+min_pickup_stacks = 1
+mean_pickup_stacks = 10
+stack_random_method = 1

--- a/game_objects/items/consumables/regel_pod/regel_pod_inventory_info.tres
+++ b/game_objects/items/consumables/regel_pod/regel_pod_inventory_info.tres
@@ -35,3 +35,6 @@ column_span = 1
 row_span = 1
 description_text = "Preprogrammed BioGel suspended in a spherical delivery mechanism. Simply Rupture the membrane and force into any traumatic wounds for instance relief!"
 flavor_text = "ReGel. For when it has to stop."
+min_pickup_stacks = 1
+mean_pickup_stacks = 3
+stack_random_method = 1

--- a/game_objects/items/materials/polymer_pile/polymer_pile_inventory_info.tres
+++ b/game_objects/items/materials/polymer_pile/polymer_pile_inventory_info.tres
@@ -29,3 +29,6 @@ column_span = 1
 row_span = 1
 description_text = "Scrap plastic fortified with glass fiber ready to be used by a modern printer"
 flavor_text = "Polymer makes it possible"
+min_pickup_stacks = 1
+mean_pickup_stacks = 5
+stack_random_method = 1

--- a/game_objects/items/weapons/fic_rifles/s5/s5_inventory_info.tres
+++ b/game_objects/items/weapons/fic_rifles/s5/s5_inventory_info.tres
@@ -37,3 +37,6 @@ column_span = 5
 row_span = 2
 description_text = "The S5 carbine is the shortened and modernized version of the original S83 rifle. It first saw widespread use in the bush wars of latter half of the last century and civilian version saw an explosion of popularity. It’s light, accurate, and soft shooting, but old timers dislike the relative lack of power."
 flavor_text = "The truth is any good modern rifle is good enough. The determining factor is the man behind the gun"
+min_pickup_stacks = 1
+mean_pickup_stacks = 1
+stack_random_method = 0

--- a/game_objects/items/weapons/hic_rifles/pm_52/pm_52_inventory_info.tres
+++ b/game_objects/items/weapons/hic_rifles/pm_52/pm_52_inventory_info.tres
@@ -37,3 +37,6 @@ column_span = 5
 row_span = 2
 description_text = "The ZS-52 was developed shortly after the 2nd Great War to replace the service rifle, submachine gun, and light machine gun in the commie army. It didn't quite do that, but it they did make a ton of them. This one is in decent condition"
 flavor_text = "The PM-52 is not a device of aggression. I devised this weapon for the security of my country - Konstantin Maksim"
+min_pickup_stacks = 1
+mean_pickup_stacks = 1
+stack_random_method = 0

--- a/helpers/helpers.gd
+++ b/helpers/helpers.gd
@@ -182,14 +182,14 @@ func convert_godot_vector_to_quake_vector(gv:Vector3) -> Vector3:
 	qv.z = convert_quake_unit_to_godot_unit(gv.z)
 	return qv
 
-func get_normalized_random_stack_count(mean: int, max_value: int, random_number_generator: RandomNumberGenerator) -> int:
+func get_normalized_random_stack_count(min_value: int, mean: int, max_value: int, random_number_generator: RandomNumberGenerator = RandomNumberGenerator.new()) -> int:
 	var sigma = (max_value - mean) / 2.0
 	var random_normal_value = random_number_generator.randfn(mean, sigma)
+	print('Normalized!!! {pulled_value}'.format({'pulled_value': str(random_normal_value)}) )
 		
-	if random_normal_value < 1:
-		return 1
+	if random_normal_value < min_value:
+		return min_value
 	elif random_normal_value > max_value:
 		return max_value
 	else:
 		return int(snapped(random_normal_value, 1))
-

--- a/helpers/helpers.gd
+++ b/helpers/helpers.gd
@@ -182,10 +182,13 @@ func convert_godot_vector_to_quake_vector(gv:Vector3) -> Vector3:
 	qv.z = convert_quake_unit_to_godot_unit(gv.z)
 	return qv
 
-func get_normalized_random_stack_count(min_value: int, mean: int, max_value: int, random_number_generator: RandomNumberGenerator = RandomNumberGenerator.new()) -> int:
+func get_normalized_random_stack_count(min_value: int,
+									   mean: int, 
+									   max_value: int, 
+									   random_number_generator: RandomNumberGenerator = RandomNumberGenerator.new()) -> int:
 	var sigma = (max_value - mean) / 2.0
 	var random_normal_value = random_number_generator.randfn(mean, sigma)
-	print_debug('Normalized!!! {pulled_value}'.format({'pulled_value': str(random_normal_value)}) )
+	print_if_debug('Normalized!!! {pulled_value}'.format({'pulled_value': str(random_normal_value)}) )
 		
 	if random_normal_value < min_value:
 		return min_value
@@ -193,3 +196,7 @@ func get_normalized_random_stack_count(min_value: int, mean: int, max_value: int
 		return max_value
 	else:
 		return int(snapped(random_normal_value, 1))
+
+func print_if_debug(x):
+	if OS.is_debug_build():
+		print_debug(x)

--- a/helpers/helpers.gd
+++ b/helpers/helpers.gd
@@ -181,3 +181,15 @@ func convert_godot_vector_to_quake_vector(gv:Vector3) -> Vector3:
 	qv.y = convert_quake_unit_to_godot_unit(gv.y)
 	qv.z = convert_quake_unit_to_godot_unit(gv.z)
 	return qv
+
+func get_normalized_random_stack_count(mean: int, max_value: int, random_number_generator: RandomNumberGenerator) -> int:
+	var sigma = (max_value - mean) / 2.0
+	var random_normal_value = random_number_generator.randfn(mean, sigma)
+		
+	if random_normal_value < 1:
+		return 1
+	elif random_normal_value > max_value:
+		return max_value
+	else:
+		return int(snapped(random_normal_value, 1))
+

--- a/levels/demo_level.tscn
+++ b/levels/demo_level.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=81 format=3 uid="uid://ctahsvj88g1om"]
+[gd_scene load_steps=83 format=3 uid="uid://ctahsvj88g1om"]
 
 [ext_resource type="PackedScene" uid="uid://d08aatgxmymbf" path="res://game_objects/player/player.tscn" id="1_eisjc"]
 [ext_resource type="Script" path="res://levels/multi_agent_navigation_root.gd" id="2_cimua"]
-[ext_resource type="Resource" uid="uid://hw8blc564g2i" path="res://levels/roomba_nav_mesh.tres" id="2_mvgx8"]
-[ext_resource type="Resource" uid="uid://bkm06qpqovt7f" path="res://levels/humanoid_nav_mesh.tres" id="3_pa7d4"]
+[ext_resource type="Resource" path="res://levels/roomba_nav_mesh.tres" id="2_mvgx8"]
+[ext_resource type="Resource" path="res://levels/humanoid_nav_mesh.tres" id="3_pa7d4"]
 [ext_resource type="PackedScene" uid="uid://trlm60n2q0k4" path="res://game_objects/items/attachments/scopes/red_dot/red_dot.tscn" id="8_2b85p"]
 [ext_resource type="PackedScene" uid="uid://cprpop5lkmyhe" path="res://game_objects/items/weapons/fic_rifles/s5/s5.tscn" id="9_7oj7m"]
 [ext_resource type="Script" path="res://levels/entities/geo_ballistic_solid.gd" id="9_q4meu"]
@@ -15,6 +15,8 @@
 [ext_resource type="Material" uid="uid://tid6vrqw40j3" path="res://levels/textures/metal/metal_2.tres" id="13_muntg"]
 [ext_resource type="Material" uid="uid://cjqyc6t2lsv8d" path="res://levels/textures/metal/metal_5.tres" id="14_3ru35"]
 [ext_resource type="Material" uid="uid://cnqi48f8iiy13" path="res://levels/textures/metal/metal_6.tres" id="15_b757u"]
+[ext_resource type="PackedScene" uid="uid://82pjqxlmcg2v" path="res://game_objects/items/ammo/hic/hic_box_ap.tscn" id="15_lbv4t"]
+[ext_resource type="PackedScene" uid="uid://c17uhpgl0dvt4" path="res://game_objects/items/ammo/fic/fic_box_fmj.tscn" id="16_3j2uw"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_6g5uc"]
 
@@ -1209,6 +1211,27 @@ transform = Transform3D(0.846085, 0.142345, -0.513691, -0.165908, 0.986141, 0, 0
 [node name="S5" parent="MultiAgentNavigationRoot" instance=ExtResource("9_7oj7m")]
 transform = Transform3D(0.28034, 0.0823512, -0.956362, -0.224502, -0.963056, -0.148736, -0.933278, 0.256402, -0.251495, 0.524934, 0.92531, -0.402487)
 _gun_stats = SubResource("Resource_r5vvs")
+
+[node name="HicBoxAp" parent="MultiAgentNavigationRoot" instance=ExtResource("15_lbv4t")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.70498, 0.227854, -0.46793)
+
+[node name="HicBoxAp2" parent="MultiAgentNavigationRoot" instance=ExtResource("15_lbv4t")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.05126, 0.162076, -0.53644)
+
+[node name="FicBoxFmj4" parent="MultiAgentNavigationRoot" node_paths=PackedStringArray("model_node") instance=ExtResource("16_3j2uw")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.84607, 0.34175, -2.72305)
+model_node = NodePath("../FicBoxFmj/fic_box_fmj")
+
+[node name="FicBoxFmj3" parent="MultiAgentNavigationRoot" node_paths=PackedStringArray("model_node") instance=ExtResource("16_3j2uw")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 7.42712, 0.296506, -2.64761)
+model_node = NodePath("../FicBoxFmj/fic_box_fmj")
+
+[node name="FicBoxFmj2" parent="MultiAgentNavigationRoot" node_paths=PackedStringArray("model_node") instance=ExtResource("16_3j2uw")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6.99314, 0.425356, -3.05)
+model_node = NodePath("../FicBoxFmj/fic_box_fmj")
+
+[node name="FicBoxFmj" parent="MultiAgentNavigationRoot" instance=ExtResource("16_3j2uw")]
+transform = Transform3D(1, 0, 0, 0, -0.491436, -0.870914, 0, 0.870914, -0.491436, 7.17928, 0.542317, -3.66029)
 
 [node name="Player" parent="." instance=ExtResource("1_eisjc")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9.48035, 1.04626, -2.63506)

--- a/resource_access/item_information.gd
+++ b/resource_access/item_information.gd
@@ -21,4 +21,6 @@ class_name ItemInformation
 @export var row_span:int = 1
 @export_multiline var description_text:String
 @export_multiline var flavor_text:String
-
+@export var min_pickup_stacks:int = 1
+@export var mean_pickup_stacks:int = 1
+@export var stack_random_method:GameplayEnums.StackRandomMethod = GameplayEnums.StackRandomMethod.RANDOM

--- a/resource_access/item_instance.gd
+++ b/resource_access/item_instance.gd
@@ -86,7 +86,20 @@ func get_item_flavor_text() -> String:
 ## after you call this you must add the instanced scenes to the scene tree
 func spawn_item() -> void:
 	if _item_info.has_stacks:
-		var stack:int = randi_range(1, _item_info.max_stacks)
+		print('HAS STACKS')
+		#Default to fun!
+		var stack:int = _item_info.max_stacks
+		if _item_info.stack_random_method == GameplayEnums.StackRandomMethod.RANDOM:
+			stack = randi_range(_item_info.min_pickup_stacks, _item_info.max_stacks)
+		elif _item_info.stack_random_method == GameplayEnums.StackRandomMethod.NORMAL:
+			stack = Helpers.get_normalized_random_stack_count(_item_info.min_pickup_stacks,
+															  _item_info.mean_pickup_stacks,
+															  _item_info.max_stacks)
+		else:
+			#Someone set an item up with a non specified random method, printing a missable
+			#error and keeping the max default for more fun!
+			printerr("{unhandled_enum_int} is an invalid integer for the GameplayEnums.StackRandomMethod enum. Defaulting to max stacks.".format({"unhandled_enum_int": _item_info.stack_random_method}))
+
 		stacks = stack
 		
 	if _item_info.item_control_scene and id_2d == 0:


### PR DESCRIPTION
Added the following settings on ItemInformation:

| Field | Description |
|---|---|
|`min_pickup_stacks` | The minimum size of the picked up stack |
|`mean_pickup_stacks` | The mid point for the normalized distribution. Midway between min and max makes the most sense, but can be skewed high or low if that's what you want. |
| `stack_random_method` | A new  StackRandomMethod enum was added to GameplayEnums. Currently only has RANDOM and NORMAL. This enum is used in item_instance code to determine how to randomize the count when picking these up. |

The method is defaulted to RANDOM. A new method was added to helpers to get a normalized random value based on the provided mean and max values set on the item information. The min value is new as well and used in both random and normal methods.

https://github.com/users/Menacing/projects/1/views/2?pane=issue&itemId=49586174

